### PR TITLE
Small fixes + Graphical Output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = {text = "MIT License"}
 readme = "README.md"
 requires-python = ">=3.7"
 dependencies = [
-    "ovito >= 3.9.0.dev35",
+    "ovito >= 3.9.1",
     "numpy >= 1.22",
 ]
 
@@ -21,4 +21,4 @@ dependencies = [
 repository = "https://github.com/killiansheriff/WarrenCowleyParameters"
 
 [project.entry-points.'OVITO.Modifier']
-"Generate Random Solution" = "WarrenCowleyParameters:WarrenCowleyParameters"
+"Warren Cowley Parameters" = "WarrenCowleyParameters:WarrenCowleyParameters"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "WarrenCowleyParameters"
-version = "2023.0"
+version = "2023.1"
 description = "OVITO Python modifier to compute Warren-Cowley parameters."
 keywords = ["ovito", "python-modifier"]
 authors = [{name = "Killian Sheriff", email = "ksheriff@mit.edu"}]

--- a/src/WarrenCowleyParameters/__init__.py
+++ b/src/WarrenCowleyParameters/__init__.py
@@ -7,6 +7,10 @@ from traits.api import List, Int
 class WarrenCowleyParameters(ModifierInterface):
     nneigh = List(Int, value=[0, 12], label="Max atoms in shells", minlen=2)
 
+    def validateInput(self):
+        if not np.all( np.diff(self.nneigh) > 0):
+            raise ValueError("'Max atoms in shells' must be strictly increasing.")
+
     def get_concentration(self, particle_types):
         unique_types, counts = np.unique(particle_types, return_counts=True)
         return unique_types, counts / len(particle_types)
@@ -34,10 +38,6 @@ class WarrenCowleyParameters(ModifierInterface):
             wc[i, :] = 1 - pij / c
 
         return wc
-
-    def validateInput(self):
-        if not np.all( np.diff(self.nneigh) > 0):
-            raise ValueError("'Max atoms in shells' must be strictly increasing.")
 
     def modify(self, data: DataCollection, frame: int, **kwargs):
         particles_types = np.array(data.particles.particle_type)

--- a/src/WarrenCowleyParameters/__init__.py
+++ b/src/WarrenCowleyParameters/__init__.py
@@ -1,11 +1,11 @@
 import numpy as np
 from ovito.data import DataCollection, NearestNeighborFinder
 from ovito.pipeline import ModifierInterface
-from traits.api import ListInt
+from traits.api import List, Int
 
 
 class WarrenCowleyParameters(ModifierInterface):
-    nneigh = ListInt([0, 12], label="Max atoms in shells", minlen=2)
+    nneigh = List(Int, value=[0, 12], label="Max atoms in shells", minlen=2)
 
     def get_concentration(self, particle_types):
         unique_types, counts = np.unique(particle_types, return_counts=True)
@@ -34,6 +34,10 @@ class WarrenCowleyParameters(ModifierInterface):
             wc[i, :] = 1 - pij / c
 
         return wc
+
+    def validateInput(self):
+        if not np.all( np.diff(self.nneigh) > 0):
+            raise ValueError("'Max atoms in shells' must be strictly increasing.")
 
     def modify(self, data: DataCollection, frame: int, **kwargs):
         particles_types = np.array(data.particles.particle_type)

--- a/src/WarrenCowleyParameters/__init__.py
+++ b/src/WarrenCowleyParameters/__init__.py
@@ -40,6 +40,7 @@ class WarrenCowleyParameters(ModifierInterface):
         return wc
 
     def modify(self, data: DataCollection, frame: int, **kwargs):
+        self.validateInput()
         particles_types = np.array(data.particles.particle_type)
         ntypes = len(np.unique(particles_types))
 


### PR DESCRIPTION
#  Changes 1

## What?

Small fixes in the usage of OVITO and traits

## Why?

- ListInt is marked depreciated by the developers of traits api [link](https://docs.enthought.com/traits/traits_api_reference/trait_types.html?highlight=listint#traits.trait_types.ListInt).
- Calling the modifier with a list like [0,12,6] leads to a non descriptive error message
- The modifier is currently showing up as "Generate Random solid solution" in the OVITO Pro modifiers list which needs to be fixed.

## How?

- Replace ListInt by List(Int...
- Write a validation function to ensure that the provided list is strictly increasing
- Rename the entry point in pyproject.toml to "Warren Cowley Parameters"
- Fix the OVITO version dependency number

# Changes 2

## What?

- Add diagram output
- Bump version number

## Why?

- Additional feature increasing functionality

## How?

- Programmatically create a bar chart for each neighbor shell  
- Assumes (and validates) symmetry for each alpha i-j / alpha j-i 
- User provided type names are used if provided

## Screenshot
![Screenshot 2023-08-08 at 10 29 01](https://github.com/killiansheriff/WarrenCowleyParameters/assets/60605180/7e623967-825f-48a6-b9e4-3cdee27668f9)
![Screenshot 2023-08-08 at 10 34 27](https://github.com/killiansheriff/WarrenCowleyParameters/assets/60605180/81c84276-aef8-421d-8903-7cb04b629764)
