### PR TITLE
Implement per-atom WC paramter calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ print(f"2NN Warren-Cowley parameters: \n {wc_for_shells[1]}")
 # Alternatively, can see it as a dictionarry
 # print(data.attributes["Warren-Cowley parameters by particle name"])
 
+# The per-particle Warren-Cowley parameter are accessible as well
+print("Per-particle 1NN Warren-Cowley parameters:\n", data.particles["Warren-Cowley parameter (shell=1)"][...])
+print("Per-particle 2NN Warren-Cowley parameters:\n", data.particles["Warren-Cowley parameter (shell=2)"][...])
+
 ```
 Example scripts can be found in the ``examples/`` folder.
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ print(f"2NN Warren-Cowley parameters: \n {wc_for_shells[1]}")
 
 
 # Alternatively, can see it as a dictionarry
-# print(data.attributes["Warren-Cowley parameters by particle name"])
+print(data.attributes["Warren-Cowley parameters by particle name"])
 
 # The per-particle Warren-Cowley parameter are accessible as well
 print("Per-particle 1NN Warren-Cowley parameters:\n", data.particles["Warren-Cowley parameter (shell=1)"][...])

--- a/examples/compute_wc.py
+++ b/examples/compute_wc.py
@@ -12,4 +12,15 @@ print(f"1NN Warren-Cowley parameters: \n {wc_for_shells[0]}")
 print(f"2NN Warren-Cowley parameters: \n {wc_for_shells[1]}")
 
 # Alternatively, can see it as a dictionarry
-# print(data.attributes["Warren-Cowley parameters by particle name"])
+print(data.attributes["Warren-Cowley parameters by particle name"])
+
+# The per-particle Warren-Cowley parameter are accessible as well
+print(
+    "Per-particle 1NN Warren-Cowley parameters:\n",
+    data.particles["Warren-Cowley parameter (shell=1)"][...],
+)
+print(
+    "Per-particle 2NN Warren-Cowley parameters:\n",
+    data.particles["Warren-Cowley parameter (shell=2)"][...],
+)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "WarrenCowleyParameters"
-version = "2.0.0"
+version = "3.0.0"
 description = "OVITO Python modifier to compute Warren-Cowley parameters."
 keywords = ["ovito", "python-modifier"]
 authors = [{name = "Killian Sheriff", email = "ksheriff@mit.edu"}]

--- a/src/WarrenCowleyParameters/__init__.py
+++ b/src/WarrenCowleyParameters/__init__.py
@@ -7,7 +7,7 @@ from traits.api import Bool, Int, List, String
 
 # Flag to compare the global WC parameter calculation to the per atom implementation
 # Should be false when running in production
-VALIDATE = True
+VALIDATE = False
 
 
 class WarrenCowleyParameters(ModifierInterface):

--- a/src/WarrenCowleyParameters/__init__.py
+++ b/src/WarrenCowleyParameters/__init__.py
@@ -128,7 +128,7 @@ class WarrenCowleyCalculator:
         ntypes = len(unique_types)
         nshells = len(self.nneigh) - 1
         wc_for_shells = np.empty((nshells, ntypes, ntypes))
-        wc_per_particles_for_shells = np.zeros((nparticles, nshells, ntypes * ntypes))
+        wc_per_particles_for_shells = np.empty((nparticles, nshells, ntypes * ntypes))
 
         # Calculate Warren-Cowley parameters for each shell
         for m in range(nshells):
@@ -183,10 +183,10 @@ class WarrenCowleyCalculator:
     def _compute_per_particle_wc_params(
         self, shell_types, central_atom_mask, concentrations, unique_types
     ):
-        wc_params_per_particle = np.zeros(
+        wc_params_per_particle = np.empty(
             (central_atom_mask.shape[1], len(concentrations) * len(concentrations))
         )
-        wc_params = np.zeros((len(concentrations), len(concentrations)))
+        wc_params = np.empty((len(concentrations), len(concentrations)))
 
         # Number of neighbor in shell
         Nb = shell_types.shape[1]


### PR DESCRIPTION
Hi,

A user requested support for calculating per-particle Warren-Cowley (WC) parameters to perform analysis similar to Figure 6b in [this paper](https://doi.org/10.1038/s41467-019-11464-7).

To support this, I refactored the `_compute_wc_params` method into `_compute_per_particle_wc_params`, where WC parameters are now calculated for each particle. The global WC parameters are then obtained by averaging the per-particle values.

I also extended the visualization class to output the per-particle arrays as OVITO particle properties, making them available for further processing or visualization.

For reference and validation, I preserved your original `_compute_wc_params` method. If the global `VALIDATE` flag at the top of the file is set to `True`, the output of the new method will be compared against your original implementation. I used this mechanism during development to help avoid any regressions.

![image](https://github.com/user-attachments/assets/86821adf-15cc-4bbd-876e-105de8dabda9)

Please let me know if you have any questions.

Cheers,
Daniel